### PR TITLE
Leading application changes for Download Multiple Attachments

### DIFF
--- a/app/admin/webapp/controller/custom.controller.js
+++ b/app/admin/webapp/controller/custom.controller.js
@@ -13,6 +13,14 @@ sap.ui.define(
         };
     
         return ControllerExtension.extend("admin.controller.custom", {
+            isDownloadEnabled: function(oBindingContext, aSelectedContexts) {
+                if (!aSelectedContexts || aSelectedContexts.length === 0) {
+                    return false;
+                }
+                return !aSelectedContexts.some(function(oContext) {
+                    return oContext.getProperty("mimeType") === "application/internet-shortcut";
+                });
+            },
             onRowPress: function(oContext) {
                 this.base.editFlow
                 .invokeAction("AdminService.openAttachment", {
@@ -90,6 +98,43 @@ sap.ui.define(
             },
             close: function (closeBtn) {
                 closeBtn.getSource().getParent().close();
+            },
+            onDownloadPress: function(oContext, aSelectedContexts) {
+                var sIds = aSelectedContexts.map(function (oCtx) {
+                    return oCtx.getObject().ID;
+                }).join(",");
+                this.base.editFlow
+                .invokeAction("AdminService.downloadSelectedAttachments", {
+                    contexts: aSelectedContexts[0],
+                    parameterValues: [{ name: "ids", value: sIds }],
+                    skipParameterDialog: true
+                })
+                .then(function (res) {
+                    var sJsonResponse = res.getObject().value;
+                    var aEntries = JSON.parse(sJsonResponse);
+                    aEntries.forEach(function (oEntry) {
+                        if (oEntry.status === "success") {
+                            if (oEntry.linkUrl) {
+                                window.open(oEntry.linkUrl, "_blank");
+                            } else if (oEntry.content) {
+                                var byteString = atob(oEntry.content);
+                                var aBytes = new Uint8Array(byteString.length);
+                                for (var i = 0; i < byteString.length; i++) {
+                                    aBytes[i] = byteString.charCodeAt(i);
+                                }
+                                var oBlob = new Blob([aBytes], { type: oEntry.mimeType || "application/octet-stream" });
+                                var sUrl = URL.createObjectURL(oBlob);
+                                var oLink = document.createElement("a");
+                                oLink.href = sUrl;
+                                oLink.download = oEntry.fileName || "download";
+                                document.body.appendChild(oLink);
+                                oLink.click();
+                                document.body.removeChild(oLink);
+                                URL.revokeObjectURL(sUrl);
+                            }
+                        }
+                    });
+                });
             }
         });
     }

--- a/app/admin/webapp/manifest.json
+++ b/app/admin/webapp/manifest.json
@@ -74,7 +74,7 @@
                     "target": "BooksDetails"
                 },
                 {
-                    "pattern": "Books({key}/author({key2}):?query:",
+                    "pattern": "Books({key})/author({key2}):?query:",
                     "name": "AuthorsDetails",
                     "target": "AuthorsDetails"
                 },
@@ -155,7 +155,7 @@
                                 "attachments/@com.sap.vocabularies.UI.v1.LineItem": {
                                     "tableSettings": {
                                         "type": "ResponsiveTable",
-                                        "selectionMode": "Auto",
+                                        "selectionMode": "Multi",
                                         "rowPress": ".extension.admin.controller.custom.onRowPress"
                                     },
                                     "actions": {
@@ -167,6 +167,16 @@
                                             "command": "COMMON", "position": { 
                                                 "anchor": "StandardAction::Create", 
                                                 "placement": "After" 
+                                            }
+                                        },
+                                        "download": {
+                                            "text": "Download",
+                                            "requiresSelection": true,
+                                            "enabled": ".extension.admin.controller.custom.isDownloadEnabled",
+                                            "press": ".extension.admin.controller.custom.onDownloadPress",
+                                            "position": {
+                                                "anchor": "StandardAction::Create", 
+                                                "placement": "After"
                                             }
                                         }
                                     }
@@ -174,7 +184,7 @@
                                 "references/@com.sap.vocabularies.UI.v1.LineItem": {
                                     "tableSettings": {
                                         "type": "ResponsiveTable",
-                                        "selectionMode": "Auto",
+                                        "selectionMode": "Multi",
                                         "rowPress": ".extension.admin.controller.custom.onRowPress"
                                     },
                                     "actions": {
@@ -187,13 +197,23 @@
                                                 "anchor": "StandardAction::Create", 
                                                 "placement": "After" 
                                             }
+                                        },
+                                        "download": {
+                                            "text": "Download",
+                                            "requiresSelection": true,
+                                            "enabled": ".extension.admin.controller.custom.isDownloadEnabled",
+                                            "press": ".extension.admin.controller.custom.onDownloadPress",
+                                            "position": {
+                                                "anchor": "StandardAction::Create", 
+                                                "placement": "After"
+                                            }
                                         }
                                     }
                                 },
                                 "footnotes/@com.sap.vocabularies.UI.v1.LineItem": {
                                     "tableSettings": {
                                         "type": "ResponsiveTable",
-                                        "selectionMode": "Auto",
+                                        "selectionMode": "Multi",
                                         "rowPress": ".extension.admin.controller.custom.onRowPress"
                                     },
                                     "actions": {
@@ -205,6 +225,16 @@
                                             "command": "COMMON", "position": { 
                                                 "anchor": "StandardAction::Create", 
                                                 "placement": "After" 
+                                            }
+                                        },
+                                        "download": {
+                                            "text": "Download",
+                                            "requiresSelection": true,
+                                            "enabled": ".extension.admin.controller.custom.isDownloadEnabled",
+                                            "press": ".extension.admin.controller.custom.onDownloadPress",
+                                            "position": {
+                                                "anchor": "StandardAction::Create", 
+                                                "placement": "After"
                                             }
                                         }
                                     }
@@ -235,7 +265,7 @@
                                 "attachments/@com.sap.vocabularies.UI.v1.LineItem": {
                                     "tableSettings": {
                                         "type": "ResponsiveTable",
-                                        "selectionMode": "Auto",
+                                        "selectionMode": "Multi",
                                         "rowPress": ".extension.admin.controller.custom.onRowPress"
                                     },
                                     "actions": {
@@ -247,6 +277,16 @@
                                             "command": "COMMON", "position": { 
                                                 "anchor": "StandardAction::Create", 
                                                 "placement": "After" 
+                                            }
+                                        },
+                                        "download": {
+                                            "text": "Download",
+                                            "requiresSelection": true,
+                                            "enabled": ".extension.admin.controller.custom.isDownloadEnabled",
+                                            "press": ".extension.admin.controller.custom.onDownloadPress",
+                                            "position": {
+                                                "anchor": "StandardAction::Create", 
+                                                "placement": "After"
                                             }
                                         }
                                     }
@@ -254,7 +294,7 @@
                                 "references/@com.sap.vocabularies.UI.v1.LineItem": {
                                     "tableSettings": {
                                         "type": "ResponsiveTable",
-                                        "selectionMode": "Auto",
+                                        "selectionMode": "Multi",
                                         "rowPress": ".extension.admin.controller.custom.onRowPress"
                                     },
                                     "actions": {
@@ -267,13 +307,23 @@
                                                 "anchor": "StandardAction::Create", 
                                                 "placement": "After" 
                                             }
+                                        },
+                                        "download": {
+                                            "text": "Download",
+                                            "requiresSelection": true,
+                                            "enabled": ".extension.admin.controller.custom.isDownloadEnabled",
+                                            "press": ".extension.admin.controller.custom.onDownloadPress",
+                                            "position": {
+                                                "anchor": "StandardAction::Create", 
+                                                "placement": "After"
+                                            }
                                         }
                                     }
                                 },
                                 "footnotes/@com.sap.vocabularies.UI.v1.LineItem": {
                                     "tableSettings": {
                                         "type": "ResponsiveTable",
-                                        "selectionMode": "Auto",
+                                        "selectionMode": "Multi",
                                         "rowPress": ".extension.admin.controller.custom.onRowPress"
                                     },
                                     "actions": {
@@ -285,6 +335,16 @@
                                             "command": "COMMON", "position": { 
                                                 "anchor": "StandardAction::Create", 
                                                 "placement": "After" 
+                                            }
+                                        },
+                                        "download": {
+                                            "text": "Download",
+                                            "requiresSelection": true,
+                                            "enabled": ".extension.admin.controller.custom.isDownloadEnabled",
+                                            "press": ".extension.admin.controller.custom.onDownloadPress",
+                                            "position": {
+                                                "anchor": "StandardAction::Create", 
+                                                "placement": "After"
                                             }
                                         }
                                     }
@@ -306,7 +366,7 @@
                                 "attachments/@com.sap.vocabularies.UI.v1.LineItem": {
                                     "tableSettings": {
                                         "type": "ResponsiveTable",
-                                        "selectionMode": "Auto",
+                                        "selectionMode": "Multi",
                                         "rowPress": ".extension.admin.controller.custom.onRowPress"
                                     },
                                     "actions": {
@@ -318,6 +378,16 @@
                                             "command": "COMMON", "position": { 
                                                 "anchor": "StandardAction::Create", 
                                                 "placement": "After" 
+                                            }
+                                        },
+                                        "download": {
+                                            "text": "Download",
+                                            "requiresSelection": true,
+                                            "enabled": ".extension.admin.controller.custom.isDownloadEnabled",
+                                            "press": ".extension.admin.controller.custom.onDownloadPress",
+                                            "position": {
+                                                "anchor": "StandardAction::Create", 
+                                                "placement": "After"
                                             }
                                         }
                                     }
@@ -325,7 +395,7 @@
                                 "references/@com.sap.vocabularies.UI.v1.LineItem": {
                                     "tableSettings": {
                                         "type": "ResponsiveTable",
-                                        "selectionMode": "Auto",
+                                        "selectionMode": "Multi",
                                         "rowPress": ".extension.admin.controller.custom.onRowPress"
                                     },
                                     "actions": {
@@ -338,13 +408,23 @@
                                                 "anchor": "StandardAction::Create", 
                                                 "placement": "After" 
                                             }
+                                        },
+                                        "download": {
+                                            "text": "Download",
+                                            "requiresSelection": true,
+                                            "enabled": ".extension.admin.controller.custom.isDownloadEnabled",
+                                            "press": ".extension.admin.controller.custom.onDownloadPress",
+                                            "position": {
+                                                "anchor": "StandardAction::Create", 
+                                                "placement": "After"
+                                            }
                                         }
                                     }
                                 },
                                 "footnotes/@com.sap.vocabularies.UI.v1.LineItem": {
                                     "tableSettings": {
                                         "type": "ResponsiveTable",
-                                        "selectionMode": "Auto",
+                                        "selectionMode": "Multi",
                                         "rowPress": ".extension.admin.controller.custom.onRowPress"
                                     },
                                     "actions": {
@@ -356,6 +436,16 @@
                                             "command": "COMMON", "position": { 
                                                 "anchor": "StandardAction::Create", 
                                                 "placement": "After" 
+                                            }
+                                        },
+                                        "download": {
+                                            "text": "Download",
+                                            "requiresSelection": true,
+                                            "enabled": ".extension.admin.controller.custom.isDownloadEnabled",
+                                            "press": ".extension.admin.controller.custom.onDownloadPress",
+                                            "position": {
+                                                "anchor": "StandardAction::Create", 
+                                                "placement": "After"
                                             }
                                         }
                                     }

--- a/srv/admin-service.cds
+++ b/srv/admin-service.cds
@@ -49,6 +49,7 @@ service AdminService @(requires: [
     ); 
     action openAttachment() returns String;
     action changelog() returns String;
+    action downloadSelectedAttachments(ids: String) returns String;
   }
   annotate AdminService.Books.attachments with @(
     Capabilities: {InsertRestrictions: {Insertable: up_.isAttachmentsUploadable}}
@@ -82,6 +83,7 @@ service AdminService @(requires: [
     );   
     action openAttachment() returns String;
     action changelog() returns String;
+    action downloadSelectedAttachments(ids: String) returns String;
   }
   annotate AdminService.Books.references with @(
     Capabilities: {InsertRestrictions: {Insertable: up_.isReferencesUploadable}}
@@ -115,6 +117,7 @@ service AdminService @(requires: [
     );  
     action openAttachment() returns String;
     action changelog() returns String;
+    action downloadSelectedAttachments(ids: String) returns String;
   }
 
   entity Pages.attachments as projection on my.Pages.attachments
@@ -145,6 +148,7 @@ service AdminService @(requires: [
     ); 
     action openAttachment() returns String;
     action changelog() returns String;
+    action downloadSelectedAttachments(ids: String) returns String;
   };
 
   entity Pages.references as projection on my.Pages.references
@@ -175,6 +179,7 @@ service AdminService @(requires: [
     ); 
     action openAttachment() returns String;
     action changelog() returns String;
+    action downloadSelectedAttachments(ids: String) returns String;
   };
 
   // Chapters projections
@@ -206,6 +211,7 @@ service AdminService @(requires: [
     ); 
     action openAttachment() returns String;
     action changelog() returns String;
+    action downloadSelectedAttachments(ids: String) returns String;
   };
 
   entity Chapters.references as projection on my.Chapters.references
@@ -236,6 +242,7 @@ service AdminService @(requires: [
     ); 
     action openAttachment() returns String;
     action changelog() returns String;
+    action downloadSelectedAttachments(ids: String) returns String;
   };
 
   entity Chapters.footnotes as projection on my.Chapters.footnotes
@@ -266,6 +273,7 @@ service AdminService @(requires: [
     ); 
     action openAttachment() returns String;
     action changelog() returns String;
+    action downloadSelectedAttachments(ids: String) returns String;
   };
 
   // Pages footnotes projection
@@ -297,6 +305,7 @@ service AdminService @(requires: [
     ); 
     action openAttachment() returns String;
     action changelog() returns String;
+    action downloadSelectedAttachments(ids: String) returns String;
   };
 
   entity Authors as projection on my.Authors;


### PR DESCRIPTION
Users can now select multiple attachments and download them all at once using a single Download button. The button intelligently disables itself when link-type entries are selected. This applies to all attachment sections across Books, Chapters and Pages