### PR TITLE
Update sideEffect to read boolean flag of parent entity on createLink

### DIFF
--- a/srv/admin-service.cds
+++ b/srv/admin-service.cds
@@ -37,7 +37,7 @@ service AdminService @(requires: [
         targetFacet: String,
         sourceFacet: String,      // Optional: if not provided, no source cleanup
     ) returns MoveAttachmentsResult;  // Return structured type
-    @(Common.SideEffects : {TargetEntities: ['']},)
+    @(Common.SideEffects : {TargetEntities: ['up_']},)
     action createLink(
       in:many $self,
       @mandatory @Common.Label:'Name' name: String @UI.Placeholder: 'Enter a name for the link',
@@ -71,7 +71,7 @@ service AdminService @(requires: [
         targetFacet: String,
         sourceFacet: String,      // Optional: if not provided, no source cleanup
     ) returns MoveAttachmentsResult;  // Return structured type
-    @(Common.SideEffects : {TargetEntities: ['']},)
+    @(Common.SideEffects : {TargetEntities: ['up_']},)
     action createLink(
       in:many $self,
       @mandatory @Common.Label:'Name' name: String @UI.Placeholder: 'Enter a name for the link',
@@ -105,7 +105,7 @@ service AdminService @(requires: [
         targetFacet: String,
         sourceFacet: String,      // Optional: if not provided, no source cleanup
     ) returns MoveAttachmentsResult;  // Return structured type
-    @(Common.SideEffects : {TargetEntities: ['']},)
+    @(Common.SideEffects : {TargetEntities: ['up_']},)
     action createLink(
       in:many $self,
       @mandatory @Common.Label:'Name' name: String @UI.Placeholder: 'Enter a name for the link',
@@ -136,7 +136,7 @@ service AdminService @(requires: [
         targetFacet: String,
         sourceFacet: String,      // Optional: if not provided, no source cleanup
     ) returns MoveAttachmentsResult;  // Return structured type
-    @(Common.SideEffects : {TargetEntities: ['']},)
+    @(Common.SideEffects : {TargetEntities: ['up_']},)
     action createLink(
       in:many $self,
       @mandatory @Common.Label:'Name' name: String @UI.Placeholder: 'Enter a name for the link',
@@ -167,7 +167,7 @@ service AdminService @(requires: [
         targetFacet: String,
         sourceFacet: String,      // Optional: if not provided, no source cleanup
     ) returns MoveAttachmentsResult;  // Return structured type
-    @(Common.SideEffects : {TargetEntities: ['']},)
+    @(Common.SideEffects : {TargetEntities: ['up_']},)
     action createLink(
       in:many $self,
       @mandatory @Common.Label:'Name' name: String @UI.Placeholder: 'Enter a name for the link',
@@ -199,7 +199,7 @@ service AdminService @(requires: [
         targetFacet: String,
         sourceFacet: String,      // Optional: if not provided, no source cleanup
     ) returns MoveAttachmentsResult;  // Return structured type
-    @(Common.SideEffects : {TargetEntities: ['']},)
+    @(Common.SideEffects : {TargetEntities: ['up_']},)
     action createLink(
       in:many $self,
       @mandatory @Common.Label:'Name' name: String @UI.Placeholder: 'Enter a name for the link',
@@ -230,7 +230,7 @@ service AdminService @(requires: [
         targetFacet: String,
         sourceFacet: String,      // Optional: if not provided, no source cleanup
     ) returns MoveAttachmentsResult;  // Return structured type
-    @(Common.SideEffects : {TargetEntities: ['']},)
+    @(Common.SideEffects : {TargetEntities: ['up_']},)
     action createLink(
       in:many $self,
       @mandatory @Common.Label:'Name' name: String @UI.Placeholder: 'Enter a name for the link',
@@ -261,7 +261,7 @@ service AdminService @(requires: [
         targetFacet: String,
         sourceFacet: String,      // Optional: if not provided, no source cleanup
     ) returns MoveAttachmentsResult;  // Return structured type
-    @(Common.SideEffects : {TargetEntities: ['']},)
+    @(Common.SideEffects : {TargetEntities: ['up_']},)
     action createLink(
       in:many $self,
       @mandatory @Common.Label:'Name' name: String @UI.Placeholder: 'Enter a name for the link',
@@ -306,7 +306,7 @@ service AdminService @(requires: [
         targetFacet: String,
         sourceFacet: String,      // Optional: if not provided, no source cleanup
     ) returns MoveAttachmentsResult;  // Return structured type
-    @(Common.SideEffects : {TargetEntities: ['']},)
+    @(Common.SideEffects : {TargetEntities: ['up_']},)
     action createLink(
       in:many $self,
       @mandatory @Common.Label:'Name' name: String @UI.Placeholder: 'Enter a name for the link',


### PR DESCRIPTION
Upload button was not getting disabled when last attachment allowed was of link type. This was because SideEffect added on Custom Link button was not refreshing/reading the parent entity. Hence, the newly defined virtual Boolean flag was never read resulting in enabled Upload button.
Added @(Common.SideEffects : {TargetEntities: ['up_']},) which allows to read parent entities metadata as well, resulting in disabling Upload button.